### PR TITLE
Fix bug in Deployment

### DIFF
--- a/.changeset/fine-nails-sort.md
+++ b/.changeset/fine-nails-sort.md
@@ -1,0 +1,5 @@
+---
+"@orbat-mapper/msdllib": patch
+---
+
+Bugfix in `Deployment` and `Federate` class where the `<Unit>` and `<EquipmentItem>` were missing a nested `<ObjectHandle>` tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@
 - 135a312: Add functionality to assign a unit to another federate in a NETN deployment.
 
   `Federate` class:
+
   - `addUnit(unitHandle: string): void`
   - `removeUnit(unitHandle: string): void`
 
   `MilitaryScenario` class:
+
   - `assignUnitToFederate(unitHandle: string, federateHandle: string): void`
   - `getFederateById(objectHandle: string): Federate | undefined`
   - `getFederateOfUnit(objectHandle: string): Federate | undefined`
@@ -24,10 +26,12 @@
 - 135a312: Add functionality to assign equipment to federates in a NETN deployment.
 
   `Federate` class:
+
   - `addEquipmentItem(equipmentItemHandle: string): void`
   - `removeEquipmentItem(equipmentItemHandle: string): void`
 
   `MilitaryScenario` class:
+
   - `getFederateOfEquipment(objectHandle: string): Federate | undefined`
   - `assignEquipmentItemToFederate(equipmentItemHandle: string, federateHandle: string): void`
 

--- a/src/test/deployment.test.ts
+++ b/src/test/deployment.test.ts
@@ -165,7 +165,9 @@ describe("Federate class", () => {
       it("should update the xml", () => {
         const xml = xmlToString(fed.element);
         expect(xml.includes("<Units>")).toBe(true);
-        expect(xml.includes(`<Unit>${uuid}</Unit>`)).toBe(true);
+        expect(
+          xml.includes(`<Unit><ObjectHandle>${uuid}</ObjectHandle></Unit>`),
+        ).toBe(true);
       });
       describe("that can also be removed", () => {
         beforeEach(() => {
@@ -177,7 +179,9 @@ describe("Federate class", () => {
         it("from the xml", () => {
           const xml = xmlToString(fed.element);
           expect(xml.includes("<Units>")).toBeFalsy();
-          expect(xml.includes(`<Unit>${uuid}</Unit>`)).toBeFalsy();
+          expect(
+            xml.includes(`<Unit><ObjectHandle>${uuid}</ObjectHandle></Unit>`),
+          ).toBeFalsy();
         });
       });
     });
@@ -193,9 +197,11 @@ describe("Federate class", () => {
       it("should update the xml", () => {
         const xml = xmlToString(fed.element);
         expect(xml.includes("<Equipment>")).toBe(true);
-        expect(xml.includes(`<EquipmentItem>${uuid}</EquipmentItem>`)).toBe(
-          true,
-        );
+        expect(
+          xml.includes(
+            `<EquipmentItem><ObjectHandle>${uuid}</ObjectHandle></EquipmentItem>`,
+          ),
+        ).toBe(true);
       });
       describe("that can also be removed", () => {
         beforeEach(() => {
@@ -208,7 +214,9 @@ describe("Federate class", () => {
           const xml = xmlToString(fed.element);
           expect(xml.includes("<Equipment>")).toBeFalsy();
           expect(
-            xml.includes(`<EquipmentItem>${uuid}</EquipmentItem>`),
+            xml.includes(
+              `<EquipmentItem><ObjectHandle>${uuid}</ObjectHandle></EquipmentItem>`,
+            ),
           ).toBeFalsy();
         });
       });


### PR DESCRIPTION
Bugfix in `Deployment` and `Federate` class where the `<Unit>` and `<EquipmentItem>` were missing a nested `<ObjectHandle>` tag