### PR TITLE
Add MILSTD_2525C to SymbologyStandard enum

### DIFF
--- a/.changeset/swift-parrots-march.md
+++ b/.changeset/swift-parrots-march.md
@@ -1,0 +1,5 @@
+---
+"@orbat-mapper/msdllib": minor
+---
+
+Add MILSTD_2525C to SymbologyStandard enum

--- a/src/lib/enums.ts
+++ b/src/lib/enums.ts
@@ -204,6 +204,7 @@ export type ModelResolutionType =
   (typeof ModelResolutionType)[keyof typeof ModelResolutionType];
 
 export const SymbologyStandard = {
+  MILSTD_2525C: "MILSTD_2525C",
   MILSTD_2525B: "MILSTD_2525B",
   NATO_APP: "NATO_APP",
 } as const;


### PR DESCRIPTION
Used in the NETN-ORG extension of MSDL
